### PR TITLE
bug-fix for the inducer option

### DIFF
--- a/src/emicore/cli.py
+++ b/src/emicore/cli.py
@@ -85,6 +85,8 @@ def namedtuple_as_dict(input):
         return {key: namedtuple_as_dict(value) for key, value in input.items()}
     if isinstance(input, (tuple, list)):
         return type(input)(namedtuple_as_dict(value) for value in input)
+    if hasattr(input, '_dictsource'):
+        return input._dictsource
     return input
 
 


### PR DESCRIPTION
## Problem: 
when --inducer option is given, the code crashes when writing the .h5  file to store the generated data with a `TypeError` 
```bash 
TypeError: Object of type LastSlackInducer is not JSON serializable
```
## Solution: 
Added if statement to namedtuple_as_dict function to fix the bug which occured with the inducer option.