### PR TITLE
VQE Kernel update and corethreshold heuristics

### DIFF
--- a/scripts/bayesian_optimization.py
+++ b/scripts/bayesian_optimization.py
@@ -252,7 +252,7 @@ class BayesOptCLI:
                 wiggle = np.random.normal(0, (max_gamma - 1) / self.args.hyperopt.steps)
                 grid_search_gamma(
                     self.model,
-                    min_gamma=1.0,
+                    min_gamma=2.0,
                     max_gamma=max_gamma + wiggle,
                     num=self.args.hyperopt.steps,
                     loss=self.args.hyperopt.loss

--- a/src/emicore/bo.py
+++ b/src/emicore/bo.py
@@ -269,8 +269,10 @@ class EMICOREOptimizer(SMOOptimizer):
         pairsize=20,
         gridsize=100,
         samplesize=100,
-        corethresh=1.0,
+        corethresh=1.,
         corethresh_width=10,
+        corethresh_scale=1.,
+        coremin_scale=0.,
         core_trials=10,
         smo_steps=100,
         smo_axis=False,
@@ -282,6 +284,8 @@ class EMICOREOptimizer(SMOOptimizer):
         self.samplesize = samplesize
         self.corethresh = corethresh
         self.corethresh_width = corethresh_width
+        self.corethresh_scale = corethresh_scale
+        self.coremin_scale = coremin_scale
         self.core_trials = core_trials
         self.smo_steps = smo_steps
         self.smo_axis = smo_axis
@@ -323,15 +327,16 @@ class EMICOREOptimizer(SMOOptimizer):
         if self.corethresh_width > 0:
             state.setdefault('energy_log', []).append(state['y_start'].item())
             if len(state['energy_log']) > self.corethresh_width:
-                state['corethresh'] = max(0., (
+                state['corethresh'] = max(self.coremin_scale * model.reg ** 0.5, (
                         state['energy_log'][-self.corethresh_width - 1] - state['energy_log'][-1]
-                    ) / self.corethresh_width
+                    ) / self.corethresh_width * self.corethresh_scale
                 )
 
         x_pairs, maximp = self._emicore(model, state, state['k_best'])
         bestind = maximp.argmax()
 
         return x_pairs[bestind]
+
 
     def require_stabilize(self, model, state):
         stabilize = (

--- a/src/emicore/cli.py
+++ b/src/emicore/cli.py
@@ -336,7 +336,7 @@ class QCParams(OptionParams):
 
 class KernelParams(OptionParams):
     sigma_0: PositiveFloat = None, 'Prior variance'
-    gamma: PositiveFloat = 1.0, 'Kernel width parameter'
+    gamma: PositiveFloat = 2.0, 'Kernel width parameter'
 
 
 class GPParams(OptionParams):
@@ -375,7 +375,7 @@ class HyperParams(OptionParams):
     threshold: PositiveFloat = 0.0, ''
     steps: int = 200, ''
     interval: str = '', ''
-    max_gamma: PositiveFloat = 10.0, ''
+    max_gamma: PositiveFloat = 20.0, ''
 
 
 class BOParams(OptionParams):

--- a/src/emicore/cli.py
+++ b/src/emicore/cli.py
@@ -308,6 +308,8 @@ OPTIMIZER_SETUPS = {
         'core_trials',
         'corethresh',
         'corethresh_width',
+        'corethresh_scale',
+        'coremin_scale',
         'smo_steps',
         'smo_axis',
     )),
@@ -363,6 +365,8 @@ class AcqParams(OptionParams):
     samplesize: int = 100, ''
     corethresh: PositiveFloat = 1.0, ''
     corethresh_width: int = 10, ''
+    corethresh_scale: float = 1.0, ''
+    coremin_scale: float = 0.0, ''
     core_trials: int = 0, ''
     smo_steps: int = 100, ''
     smo_axis: click.BOOL = False, ''

--- a/src/emicore/gp.py
+++ b/src/emicore/gp.py
@@ -233,7 +233,7 @@ class Kernel:
 class VQEKernel(Kernel):
     __kernel_params__ = ('gamma',)
 
-    def __init__(self, sigma_0=1.0, gamma=1.0, n_feature_dim=2):
+    def __init__(self, sigma_0=1.0, gamma=2.0, n_feature_dim=2):
         super().__init__(n_feature_dim=n_feature_dim)
         self.sigma_0 = sigma_0
         self.gamma = torch.tensor(gamma)
@@ -241,7 +241,7 @@ class VQEKernel(Kernel):
 
     @flatargs
     def __call__(self, x1, x2):
-        gram_matrix = (self.gamma ** 2 + torch.cos(cdiff(x1, x2))).log() - (1 + self.gamma ** 2).log()
+        gram_matrix = (self.gamma ** 2 + 2 * torch.cos(cdiff(x1, x2))).log() - (2 + self.gamma ** 2).log()
         kern = self.sigma_0_sq * gram_matrix.sum(axis=-1).exp()
         return kern
 


### PR DESCRIPTION
In this pull request, we introduce two major updates:

- We modify the VQE kernel so that it is consistent with the latest version of the paper [1]. Specifically, the VQE kernel is now a generalization of the Dirichlet kernel. 
- We introduce two new parameters `coremin_scale` and `corethresh_scale` for tuning the core threshold as discussed in the appendix of the NeurIPS paper [1].

---

[1] [Nicoli, Kim Andrea, et al. "Physics-Informed Bayesian Optimization of Variational Quantum Circuits." Thirty-seventh Conference on Neural Information Processing Systems. 2023.](https://openreview.net/forum?id=xfBeVGJwyL)